### PR TITLE
fix: update SN whatsapp group link

### DIFF
--- a/src/constants/whatsapp-links.js
+++ b/src/constants/whatsapp-links.js
@@ -1,5 +1,5 @@
 export const whatsAppGroups = {
-  SN: "https://chat.whatsapp.com/HEA93jjepI3KpyNviDjAdh",
+  SN: "https://chat.whatsapp.com/DvB0mrWpRev3r1KMqQGvjb",
   M: "https://chat.whatsapp.com/IlOCSN4SDWlB2qYE6xl62C",
   TMGM: "https://chat.whatsapp.com/IlOCSN4SDWlB2qYE6xl62C",
   TSGE: "https://chat.whatsapp.com/IlOCSN4SDWlB2qYE6xl62C",


### PR DESCRIPTION
Updates the SN WhatsApp group link to the new URL as requested in issue #5.

Changes:
- Updated `src/constants/whatsapp-links.js` with the new SN group link

Closes #5

Generated with [Claude Code](https://claude.ai/code)